### PR TITLE
Send API credentials with requests to TfL API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+TFL_APP_ID=<my app id>
+TFL_APP_KEY=<my app key>

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ elm-stuff
 node_modules
 npm-debug.log
 dist
+.env

--- a/README.md
+++ b/README.md
@@ -9,5 +9,6 @@ Live TfL bus countdown written in Elm. This is a work in progress.
 ```sh
 $ npm install
 $ elm-package install
+$ cp .env.example .env # and edit
 $ npm run dev
 ```

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "webpack.config.js",
   "dependencies": {
     "ace-css": "^1.1.0",
+    "dotenv": "^2.0.0",
     "font-awesome": "^4.7.0",
     "signalr": "^2.2.1"
   },

--- a/src/Model.elm
+++ b/src/Model.elm
@@ -1,4 +1,4 @@
-module Model exposing (Model, State(..), emptyModel)
+module Model exposing (Model, State(..), emptyModel, resetModel)
 
 import Dict exposing (Dict)
 import Prediction exposing (Prediction)
@@ -20,8 +20,14 @@ type alias Model =
     , predictions : Dict String Prediction
     , possibleStops : List Stop
     , state : State
+    , tfl_app_id : String
+    , tfl_app_key : String
     }
 
 
 emptyModel =
-    Model "" Dict.empty [] Initial
+    Model "" Dict.empty [] Initial "" ""
+
+
+resetModel model =
+    { emptyModel | tfl_app_id = model.tfl_app_id, tfl_app_key = model.tfl_app_key }

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,10 @@ if (!window.location.host.match(/^localhost/) && window.location.protocol != "ht
 }
 
 const elmDiv = document.querySelector("#main");
-const elmApp = Elm.Main.embed(elmDiv);
+const elmApp = Elm.Main.embed(elmDiv, {
+  tfl_app_id: process.env.TFL_APP_ID,
+  tfl_app_key: process.env.TFL_APP_KEY
+});
 
 $.connection.hub.url = "https://push-api.tfl.gov.uk/signalr/hubs/signalr";
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 var webpack = require("webpack");
 var CopyWebpackPlugin = require('copy-webpack-plugin');
+var dotenv = require('dotenv').config();
 
 module.exports = {
   context: __dirname + "/src",
@@ -50,6 +51,7 @@ module.exports = {
     new CopyWebpackPlugin([
       { from: 'css/main.css', to: "css/main.css" },
       { from: 'css/pure-min.css', to: "css/pure-min.css" }
-    ])
+    ]),
+    new webpack.EnvironmentPlugin(["TFL_APP_ID", "TFL_APP_KEY"])
   ]
 };


### PR DESCRIPTION
API credentials are baked into the compiled app but are not in source control.

Manage reading API credentials from the environment with https://www.npmjs.com/package/dotenv and Webpack's [`EnvironmentPlugin`](https://github.com/webpack/docs/wiki/list-of-plugins#environmentplugin).

These are then passed to the Elm app as flags (see https://guide.elm-lang.org/interop/javascript.html).