### PR TITLE
Navigation

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -12,7 +12,8 @@
         "elm-community/json-extra": "2.0.0 <= v < 3.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0",
-        "elm-lang/http": "1.0.0 <= v < 2.0.0"
+        "elm-lang/http": "1.0.0 <= v < 2.0.0",
+        "elm-lang/navigation": "2.0.1 <= v < 3.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/src/Model.elm
+++ b/src/Model.elm
@@ -2,6 +2,7 @@ module Model exposing (Model, State(..), resetModel)
 
 import Dict exposing (Dict)
 import NaptanId exposing (NaptanId)
+import Navigation
 import Prediction exposing (Prediction)
 import Stop exposing (Stop)
 
@@ -24,8 +25,10 @@ type alias Model =
     , state : State
     , tfl_app_id : String
     , tfl_app_key : String
+    , currentRoute : Navigation.Location
     }
 
 
+resetModel : Model -> Model
 resetModel model =
     { model | naptanId = Nothing, predictions = Dict.empty, possibleStops = [], state = Initial }

--- a/src/Routing.elm
+++ b/src/Routing.elm
@@ -1,0 +1,13 @@
+module Routing exposing (RoutePath, fromLocation)
+
+import List exposing (drop)
+import Navigation
+
+
+type alias RoutePath =
+    List String
+
+
+fromLocation : Navigation.Location -> RoutePath
+fromLocation { hash } =
+    hash |> String.split "/" |> drop 1


### PR DESCRIPTION
Give pages distinct routes so they're navigable directly and browser navigation works as expected.

The following routes exist:

`/#/` => Initial page
`/#/locations/find` => Find my current location ("forwards" to next route on success)
`/#/locations/:lat/:long` => Show stops nearby the specified lat/long
`/#/stops/:naptanId` => Show arrivals for the stop specified